### PR TITLE
Fix modTemperature NaN/Inf handling

### DIFF
--- a/common/src/main/kotlin/org/valkyrienskies/kelvin/impl/DuctNetworkServer.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/kelvin/impl/DuctNetworkServer.kt
@@ -176,7 +176,10 @@ class DuctNetworkServer(
     }
 
     override fun modTemperature(pos: DuctNodePos, deltaTemperature: Double) {
-        if (deltaTemperature.isNaN() || deltaTemperature.isInfinite()) nodeInfo[pos]?.currentTemperature = 0.0001
+        if (deltaTemperature.isNaN() || deltaTemperature.isInfinite()) {
+            nodeInfo[pos]?.currentTemperature = 0.0001
+            return
+        }
         nodeInfo[pos]?.currentTemperature = max(nodeInfo[pos]?.currentTemperature?.plus(deltaTemperature) ?: 0.0001, 0.0001)
     }
 


### PR DESCRIPTION
NaN and Inf are treated as the max value in `max`, meaning they get propagated through the system. 

Why nodes sometimes end up with NaN temperature in the first place, I have no idea, but fixing the check is probably an alright first step.