### PR TITLE
Lang-ify gas reactions

### DIFF
--- a/common/src/main/kotlin/org/valkyrienskies/kelvin/KelvinMod.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/kelvin/KelvinMod.kt
@@ -35,7 +35,7 @@ object KelvinMod {
 
     const val chunkSaveID = "KELVIN_CHUNK_INFO"
 
-    val KELVINLOGGER = logger("Meringue Factory").logger
+    val KELVINLOGGER = logger("(Kelvin) Meringue Factory").logger
 
     lateinit var networkManager: SimpleNetworkManager
 

--- a/common/src/main/kotlin/org/valkyrienskies/kelvin/KelvinMod.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/kelvin/KelvinMod.kt
@@ -27,7 +27,7 @@ object KelvinMod {
 
     const val chunkSaveID = "KELVIN_CHUNK_INFO"
 
-    val KELVINLOGGER = logger("(Kelvin) Meringue Factory").logger
+    val KELVINLOGGER = logger("Meringue Factory").logger
 
     lateinit var networkManager: SimpleNetworkManager
 

--- a/common/src/main/kotlin/org/valkyrienskies/kelvin/KelvinMod.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/kelvin/KelvinMod.kt
@@ -1,21 +1,16 @@
 package org.valkyrienskies.kelvin
 
-import com.fasterxml.jackson.module.kotlin.readValue
 import dev.architectury.event.events.client.ClientPlayerEvent
 import dev.architectury.event.events.client.ClientTickEvent
-import dev.architectury.event.events.common.ChunkEvent
 import dev.architectury.event.events.common.LifecycleEvent
 import dev.architectury.event.events.common.TickEvent
 import dev.architectury.networking.simple.SimpleNetworkManager
 import dev.architectury.platform.Platform
 import dev.architectury.utils.Env
 import net.minecraft.client.multiplayer.ClientLevel
-import net.minecraft.nbt.CompoundTag
 import net.minecraft.resources.ResourceLocation
 import net.minecraft.server.level.ServerLevel
-import net.minecraft.world.level.chunk.ChunkAccess
 import org.valkyrienskies.kelvin.api.DuctNetwork
-import org.valkyrienskies.kelvin.api.DuctNodePos
 import org.valkyrienskies.kelvin.debug.KelvinBlocks
 import org.valkyrienskies.kelvin.impl.DuctNetworkServer
 import org.valkyrienskies.kelvin.impl.client.DuctNetworkClient
@@ -24,10 +19,7 @@ import org.valkyrienskies.kelvin.impl.registry.GasParticlePickerRegistry
 import org.valkyrienskies.kelvin.impl.registry.GasTypeRegistry
 import org.valkyrienskies.kelvin.impl.registry.ReactionRequirementRegistry
 import org.valkyrienskies.kelvin.networking.KelvinNetworking
-import org.valkyrienskies.kelvin.serialization.SerializableDuctNetwork
-import org.valkyrienskies.kelvin.util.KelvinChunkPos
 import org.valkyrienskies.kelvin.util.KelvinDamageSources
-import org.valkyrienskies.kelvin.util.KelvinJacksonUtil
 
 
 object KelvinMod {
@@ -181,7 +173,11 @@ object KelvinMod {
         return KelvinClient
     }
 
-    fun asResouceLocation(string: String): ResourceLocation {
+    // Backwards compatibility ig
+    @Deprecated(message = "Use asResourceLocation instead")
+    fun asResouceLocation(string: String): ResourceLocation = asResourceLocation(string)
+
+    fun asResourceLocation(string: String): ResourceLocation {
         return ResourceLocation("${MOD_ID}:$string")
     }
 }

--- a/common/src/main/kotlin/org/valkyrienskies/kelvin/api/GasType.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/kelvin/api/GasType.kt
@@ -34,6 +34,6 @@ data class GasType(
     }
 
     companion object {
-        val PLACEHOLDER_ICON = KelvinMod.asResouceLocation("textures/icons/placeholder.png")
+        val PLACEHOLDER_ICON = KelvinMod.asResourceLocation("textures/icons/placeholder.png")
     }
 }

--- a/common/src/main/kotlin/org/valkyrienskies/kelvin/impl/recipe/DefaultKelvinRequirements.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/kelvin/impl/recipe/DefaultKelvinRequirements.kt
@@ -5,6 +5,7 @@ import net.minecraft.network.chat.Component
 import net.minecraft.resources.ResourceLocation
 import net.minecraft.world.level.Level
 import org.valkyrienskies.kelvin.KelvinMod
+import org.valkyrienskies.kelvin.KelvinMod.MOD_ID
 import org.valkyrienskies.kelvin.api.DuctNetwork
 import org.valkyrienskies.kelvin.api.DuctNodePos
 import org.valkyrienskies.kelvin.api.recipe.GasReactionRequirement
@@ -24,12 +25,12 @@ object DefaultKelvinRequirements {
         override fun get_text(value: JsonElement): Component {
             val doubleValue = value.asDouble
 
-            return Component.literal("Minimum Temperature: $doubleValue K")
+            return Component.translatable("$MOD_ID.requirements.min_temperature", doubleValue)
         }
 
     }
 
-    object maxTemperature: GasReactionRequirement(KelvinMod.asResouceLocation("max_temperature")) {
+    object maxTemperature: GasReactionRequirement(KelvinMod.asResourceLocation("max_temperature")) {
         override fun apply_requirement(level: Level, ductNode: DuctNodePos, network: DuctNetwork<*>, value: JsonElement): Boolean {
             val doubleValue = value.asDouble
 
@@ -40,11 +41,11 @@ object DefaultKelvinRequirements {
         override fun get_text(value: JsonElement): Component {
             val doubleValue = value.asDouble
 
-            return Component.literal("Maximum Temperature: $doubleValue K")
+            return Component.translatable("$MOD_ID.requirements.max_temperature", doubleValue)
         }
     }
 
-    object minPressure: GasReactionRequirement(KelvinMod.asResouceLocation("min_pressure")) {
+    object minPressure: GasReactionRequirement(KelvinMod.asResourceLocation("min_pressure")) {
         override fun apply_requirement(level: Level, ductNode: DuctNodePos, network: DuctNetwork<*>, value: JsonElement): Boolean {
             val doubleValue = value.asDouble
 
@@ -55,11 +56,11 @@ object DefaultKelvinRequirements {
         override fun get_text(value: JsonElement): Component {
             val doubleValue = value.asDouble
 
-            return Component.literal("Minimum Pressure: $doubleValue Pa")
+            return Component.translatable("$MOD_ID.requirements.min_pressure", doubleValue)
         }
     }
 
-    object maxPressure: GasReactionRequirement(KelvinMod.asResouceLocation("max_pressure")) {
+    object maxPressure: GasReactionRequirement(KelvinMod.asResourceLocation("max_pressure")) {
         override fun apply_requirement(level: Level, ductNode: DuctNodePos, network: DuctNetwork<*>, value: JsonElement): Boolean {
             val doubleValue = value.asDouble
 
@@ -70,11 +71,11 @@ object DefaultKelvinRequirements {
         override fun get_text(value: JsonElement): Component {
             val doubleValue = value.asDouble
 
-            return Component.literal("Maximum Pressure: $doubleValue Pa")
+            return Component.translatable("$MOD_ID.requirements.max_pressure", doubleValue)
         }
     }
 
-    object inhibitedBy: GasReactionRequirement(KelvinMod.asResouceLocation("inhibited_by")) {
+    object inhibitedBy: GasReactionRequirement(KelvinMod.asResourceLocation("inhibited_by")) {
         override fun apply_requirement(level: Level, ductNode: DuctNodePos, network: DuctNetwork<*>, value: JsonElement): Boolean {
             val gasTypeId = value.asJsonObject["gas"].asString
             val gasType = GasTypeRegistry.getGasType(ResourceLocation.of(gasTypeId, ':'))
@@ -87,10 +88,18 @@ object DefaultKelvinRequirements {
         }
 
         override fun get_text(value: JsonElement): Component {
-            val gasType = value.asJsonObject["gas"].asString
+            val gasType = value.asJsonObject["gas"].getGasName()
             val ratio = value.asJsonObject["ratio"].asDouble
 
-            return Component.literal("Inhibited by: $gasType(${ratio*100}%)")
+            return Component.translatable("$MOD_ID.requirements.inhibited_by", gasType, ratio*100)
+            //return Component.literal("Inhibited by: $gasType(${ratio*100}%)")
         }
     }
+}
+
+/**
+ * Assumes the JsonElement is a String resource location for a registered gas
+ */
+private fun JsonElement.getGasName(): String {
+    return GasTypeRegistry.getGasType(ResourceLocation(this.asString))?.name ?: this.asString
 }

--- a/common/src/main/kotlin/org/valkyrienskies/kelvin/impl/recipe/DefaultKelvinRequirements.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/kelvin/impl/recipe/DefaultKelvinRequirements.kt
@@ -14,7 +14,7 @@ import org.valkyrienskies.kelvin.impl.registry.GasTypeRegistry
 object DefaultKelvinRequirements {
     val defaultRequirements = listOf(minTemperature, maxTemperature, minPressure, maxPressure, inhibitedBy)
 
-    object minTemperature: GasReactionRequirement(KelvinMod.asResouceLocation("min_temperature")) {
+    object minTemperature: GasReactionRequirement(KelvinMod.asResourceLocation("min_temperature")) {
         override fun apply_requirement(level: Level, ductNode: DuctNodePos, network: DuctNetwork<*>, value: JsonElement): Boolean {
             val doubleValue = value.asDouble
 

--- a/common/src/main/kotlin/org/valkyrienskies/kelvin/impl/registry/GasTypeRegistry.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/kelvin/impl/registry/GasTypeRegistry.kt
@@ -42,7 +42,7 @@ object GasTypeRegistry {
     }
 
     private fun getIcon(name: String): ResourceLocation {
-        return KelvinMod.asResouceLocation("textures/icons/$name.png")
+        return KelvinMod.asResourceLocation("textures/icons/$name.png")
     }
 
     fun init () {

--- a/common/src/main/kotlin/org/valkyrienskies/kelvin/integration/jei/KelvinGasIngredient.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/kelvin/integration/jei/KelvinGasIngredient.kt
@@ -60,12 +60,14 @@ class GasIngredientRenderer: IIngredientRenderer<KelvinGasIngredient> {
         guiGraphics.pose().pushPose();
         guiGraphics.pose().scale(0.5f, 0.5f, 1.0f);
 
-        for (xOffset in -1..1)
-            for (yOffset in -1..1)
-                guiGraphics.drawString(Minecraft.getInstance().font, KelvinTextHandler.mass(ingredient.mass), 6 *2 + xOffset, 10 *2 + yOffset, 853249 , false)
+        if (ingredient.mass > 0) {
+            for (xOffset in -1..1)
+                for (yOffset in -1..1)
+                    guiGraphics.drawString(Minecraft.getInstance().font, KelvinTextHandler.mass(ingredient.mass), 6 *2 + xOffset, 10 *2 + yOffset, 853249 , false)
 
-        guiGraphics.drawString(Minecraft.getInstance().font, KelvinTextHandler.mass(ingredient.mass), 6 *2, 10 *2, 16777215, false)
+            guiGraphics.drawString(Minecraft.getInstance().font, KelvinTextHandler.mass(ingredient.mass), 6 *2, 10 *2, 16777215, false)
 
+        }
 
         guiGraphics.pose().popPose();
     }

--- a/common/src/main/kotlin/org/valkyrienskies/kelvin/integration/jei/KelvinJeiPlugin.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/kelvin/integration/jei/KelvinJeiPlugin.kt
@@ -23,7 +23,7 @@ class KelvinJeiPlugin: IModPlugin {
 
     override fun registerIngredients(registration: IModIngredientRegistration) {
         val recipes = HashSet<KelvinGasIngredient>()
-        GasTypeRegistry.GAS_TYPES.values.forEach {type -> recipes.add(KelvinGasIngredient(type, 1.0))}
+        GasTypeRegistry.GAS_TYPES.values.forEach {type -> recipes.add(KelvinGasIngredient(type, 0.0))}
         registration.register(GAS_INGREDIENT_TYPE, recipes, GasIngredientHelper(), GasIngredientRenderer())
     }
 

--- a/common/src/main/kotlin/org/valkyrienskies/kelvin/integration/jei/KelvinJeiPlugin.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/kelvin/integration/jei/KelvinJeiPlugin.kt
@@ -18,7 +18,7 @@ import org.valkyrienskies.kelvin.impl.registry.GasTypeRegistry
 @JeiPlugin
 class KelvinJeiPlugin: IModPlugin {
     override fun getPluginUid(): ResourceLocation {
-        return KelvinMod.asResouceLocation("jei_plugin")
+        return KelvinMod.asResourceLocation("jei_plugin")
     }
 
     override fun registerIngredients(registration: IModIngredientRegistration) {

--- a/common/src/main/kotlin/org/valkyrienskies/kelvin/integration/jei/KelvinReactionRecipeCategory.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/kelvin/integration/jei/KelvinReactionRecipeCategory.kt
@@ -19,7 +19,7 @@ import org.valkyrienskies.kelvin.integration.jei.KelvinJeiPlugin.Companion.GAS_I
 class KelvinReactionRecipeCategory : IRecipeCategory<GasBaseRecipe> {
 
     override fun getBackground(): IDrawable {
-        return ImageDrawable(150, 150, KelvinMod.asResouceLocation("textures/gui/gas_reaction_recipe_background.png"))
+        return ImageDrawable(150, 150, KelvinMod.asResourceLocation("textures/gui/gas_reaction_recipe_background.png"))
     }
 
     override fun getRecipeType(): RecipeType<GasBaseRecipe> {

--- a/common/src/main/resources/assets/kelvin/lang/en_us.json
+++ b/common/src/main/resources/assets/kelvin/lang/en_us.json
@@ -1,0 +1,7 @@
+{
+  "kelvin.requirements.inhibited_by": "Inhibited by: %s (%s%%)",
+  "kelvin.requirements.max_pressure": "Maximum Pressure: %s Pa",
+  "kelvin.requirements.min_pressure": "Minimum Pressure: %s Pa",
+  "kelvin.requirements.max_temperature": "Maximum Temperature: %s K",
+  "kelvin.requirements.min_temperature": "Minimum Temperature: %s K"
+}


### PR DESCRIPTION
Makes the gas reactions (for JEI) have lang strings instead of hardcoded literals.

It also makes the "inhibited_by" reaction requirement look nicer by using the gas name instead of the gas resource location. 

It also renames 
```kotlin
fun asResouceLocation(string: String): ResourceLocation
```
in `KelvinMod` to 
```kotlin
fun asResourceLocation(string: String): ResourceLocation
```
but leaves the old method just incase it was needed by another mod